### PR TITLE
fix(tc): add export treeNode type

### DIFF
--- a/src/types/TreeNode.ts
+++ b/src/types/TreeNode.ts
@@ -25,7 +25,7 @@ export interface Route {
   params?: Params[];
 }
 
-interface TreeNode {
+export interface TreeNode {
   name: string;
   attributes:
     | {


### PR DESCRIPTION
il manque tree node en export de type pour qu'on puisse import { TreegeConsumer, TreeNode } from "treege-consumer";